### PR TITLE
[GRDM-31295] datascience-notebookベースイメージに default CRAN mirror を追加

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -1,5 +1,7 @@
 FROM jupyter/datascience-notebook:lab-3.4.0
 
+COPY --chown=$NB_UID:$NB_GID ./python/Rprofile $HOME/.Rprofile
+
 # Installing CS-jupyterlab-grdm https://github.com/RCOSDP/CS-jupyterlab-grdm/
 ENV grdm_jlab_release_tag=0.1.0 \
     grdm_jlab_release_url=https://github.com/RCOSDP/CS-jupyterlab-grdm/releases/download/0.1.0

--- a/python/Rprofile
+++ b/python/Rprofile
@@ -1,0 +1,1 @@
+options(repos=structure(c(CRAN="https://cran.ism.ac.jp/")))


### PR DESCRIPTION
イメージにdefault CRAN mirrorを指定していなかったために、datascience-notebookイメージに対するGRDMアドオンでの`R (CRAN)`パッケージ指定が以下のエラーで正常に動作しないようでした。
そのため、デフォルトのCRAN mirror https://cran.ism.ac.jp/ にするような修正を行いました。

```
Rscript -e 'remotes::install_version("devtools", "1.11.0")'
Error in contrib.url(repos, type) : 
  trying to use CRAN without setting a mirror
Calls: <Anonymous> -> download_version_url -> contrib.url
Execution halted
```